### PR TITLE
Adds Física Universitaria Volumen 2 to book list

### DIFF
--- a/bakery/src/scripts/canonical-book-list.json
+++ b/bakery/src/scripts/canonical-book-list.json
@@ -151,6 +151,10 @@
         {
             "uuid": "175c88b6-f89b-4eba-9514-bc45e2139a1d",
             "_name": "Física Universitaria Volumen 1"
+        },
+        {
+            "uuid": "da02605d-6d69-447c-a9b9-caf06dc4f413",
+            "_name": "Física Universitaria Volumen 2"
         }
     ]
 }


### PR DESCRIPTION
So that links to vol2 from vol3 will know to use the vol2 book

Refs https://github.com/openstax/ce/issues/1738