### PR TITLE
Wrap DBSessionMiddleware request in try except block

### DIFF
--- a/backend/app/app/middleware.py
+++ b/backend/app/app/middleware.py
@@ -1,5 +1,6 @@
 import logging
 
+from fastapi import Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.db.session import Session
@@ -7,9 +8,17 @@ from app.db.session import Session
 
 class DBSessionMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        logging.info(f"Creating Database session for {request.url}")
-        request.state.db = Session()
-        response = await call_next(request)
-        logging.info(f"Closing Database session for {request.url}")
-        request.state.db.close()
+        logging.debug(f"Creating Database session for {request.url}")
+        response = Response("Internal server error", status_code=500)
+        # https://fastapi.tiangolo.com/tutorial/sql-databases/#create-a-middleware
+        try: 
+            request.state.db = Session()
+            response = await call_next(request)
+        # We log the exception because it could be one of many.
+        except Exception(e):
+            logging.exception(e)
+        # Always close the db session, even after an exception
+        finally:
+            logging.debug(f"Closing Database session for {request.url}")
+            request.state.db.close()
         return response


### PR DESCRIPTION
* We wrap the DBSessionMiddleware in try/except/finally block because we
  could throw any number of exceptions. Currently, we're seeing an
  connection error in SQLAlchemy due to unclosed connections.
* To help with the unclosed connection we've added a finally clause to
  ensure we always close the connection.