### PR TITLE
Added nondestructive and sensitive config/markers to fix errors

### DIFF
--- a/backend/app/setup.cfg
+++ b/backend/app/setup.cfg
@@ -1,6 +1,5 @@
 [tool:pytest]
 addopts=-vvvs --tb=long --showlocals
-sensitive_url=^(?:https?:\/\/)?corgi\.ce.openstax\.org
 xfail_strict=true
 
 [flake8]

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,3 +1,7 @@
+import re
+
+import pytest
+
 # Import fixtures
 pytest_plugins = "tests.ui.fixtures.ui"
 
@@ -12,10 +16,46 @@ def get_custom_markers():
         "smoke: mark tests used for smoke testing",
         "testrail: mark tests used for testrail runs",
         "ui: mark tests used for ui tests",
-        "unit: mark tests as a unit test"
+        "unit: mark tests as a unit test",
+        "nondestructive: tests using this decorator will run in sensitive environments",
+        "sensitive: the url for environments where destructive tests should not be executed"
     )
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("safety", "safety")
+    group.addoption(
+        "--destructive",
+        action="store_true",
+        dest="run_destructive",
+        default=False,
+        help="include destructive tests (tests not explicitly marked as \'nondestructive\'). (disabled by default).",
+    )
+    group._addoption('--sensitiveurl',
+                    action='store',
+                    dest='sensitive_url',
+                    default='corgi\.ce\.openstax\.org',
+                    metavar='str',
+                    help='regular expression for identifying sensitive urls.')
 
 
 def pytest_configure(config):
     for marker in get_custom_markers():
         config.addinivalue_line("markers", marker)
+
+    if not config.option.run_destructive:
+        if config.option.markexpr:
+            config.option.markexpr = f"nondestructive and {config.option.markexpr}"
+        else:
+            config.option.markexpr = "nondestructive"
+
+
+def pytest_runtest_setup(item):
+    sensitive = re.search(item.config.option.sensitive_url, item.config.option.base_url)
+    destructive = 'nondestructive' not in item.keywords
+
+    if (sensitive and destructive):
+        # Skip the test with an appropriate message
+        pytest.skip("This test is destructive and the target URL is" \
+                    "considered a sensitive environment. If this test" \
+                    "is not destructive add the 'nondestructive' marker.")

--- a/backend/app/tests/integration/api/endpoints/test_version.py
+++ b/backend/app/tests/integration/api/endpoints/test_version.py
@@ -6,8 +6,8 @@ from tests.utils import validate_datetime
 
 ENDPOINT = "version"
 
-
 @pytest.mark.integration
+@pytest.mark.nondestructive
 def test_version_get_request(api_url, tag, stack_name, revision):
     # GIVEN: An api url to the version endpoint
     url = f"{api_url}/{ENDPOINT}"

--- a/backend/app/tests/unit/api/endpoints/test_ping.py
+++ b/backend/app/tests/unit/api/endpoints/test_ping.py
@@ -2,8 +2,8 @@ import pytest
 
 ENDPOINT = "ping"
 
-
 @pytest.mark.unit
+@pytest.mark.nondestructive
 def test_ping_get_request(testclient):
     # GIVEN: a test client and a URL
     url = f"/api/{ENDPOINT}"

--- a/backend/app/tests/unit/test_middleware.py
+++ b/backend/app/tests/unit/test_middleware.py
@@ -27,8 +27,8 @@ app = Starlette(
     middleware=[Middleware(DBSessionMiddleware)],
 )
 
-
 @pytest.mark.unit
+@pytest.mark.nondestructive
 def test_db_session_middleware(caplog):
     # GIVEN: A test client and capture log set to DEBUG
     caplog.set_level(logging.DEBUG)

--- a/backend/app/tests/unit/test_utils.py
+++ b/backend/app/tests/unit/test_utils.py
@@ -2,6 +2,8 @@ import pytest
 
 from tests.utils import validate_datetime
 
+@pytest.mark.unit
+@pytest.mark.nondestructive
 @pytest.mark.parametrize("date_str", [("20220411.192702")])
 def test_validate_datetime_string_is_correct(date_str):
     # GIVEN: A correct datetime string
@@ -12,6 +14,9 @@ def test_validate_datetime_string_is_correct(date_str):
     # THEN: The string can be converted to python datetime obj
     assert is_date
 
+
+@pytest.mark.unit
+@pytest.mark.nondestructive
 @pytest.mark.parametrize("date_str", [("a")])
 def test_validate_datetime_string_is_incorrect(date_str):
     # GIVEN: An incorrect datetime string

--- a/docker-compose.stack.ci.yml
+++ b/docker-compose.stack.ci.yml
@@ -81,4 +81,3 @@ services:
       - '8000:8000'
     volumes:
       - ./docs:/docs
-    


### PR DESCRIPTION
## Description

When reviewing the logs of the PR pipeline I noticed a lot of errors about the nondestructive marker not existing. This is due to us removing pytest-selenium and using python-playwright as our browser testing library. The nondestructive and sensitive markers were useful so I've migrated the relevant pieces. 

An example is from the recent integration tests that ran on main: 
![2022-06-09_13-34-22](https://user-images.githubusercontent.com/8730430/172919781-6b902645-8ca2-4d04-a5c3-790e6ddb75b4.png)


The warning messages after this changeset are now gone:

![2022-06-09_13-35-43](https://user-images.githubusercontent.com/8730430/172919962-5147214b-e741-4696-9570-2cd095d45488.png)
