### PR TITLE
1834 Fix a few issues with first release of ABL button

### DIFF
--- a/backend/app/app/api/endpoints/abl.py
+++ b/backend/app/app/api/endpoints/abl.py
@@ -4,6 +4,6 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
-@router.get("/{repo_name}/{slug}/{version}")
-async def get(repo_name, slug, version):
-    return await get_abl_info(repo_name, slug, version)
+@router.get("/{repo_name}/{version}")
+async def get(repo_name, version):
+    return await get_abl_info(repo_name, version)

--- a/backend/app/app/service/abl.py
+++ b/backend/app/app/service/abl.py
@@ -8,10 +8,10 @@ from lxml import etree
 headers = {"authorization": f"token {config.GITHUB_API_TOKEN}"}
 
 
-async def get_abl_info(repo_name, slug, version="main"):
+async def get_abl_info(repo_name, version="main"):
     loop = asyncio.get_running_loop()
     metadata = await loop.run_in_executor(None, get_book_metadata,
-                                          repo_name, slug, version)
+                                          repo_name, version)
     metadata["line_number"] = await loop.run_in_executor(
         None, get_abl_line_number, repo_name)
 
@@ -28,7 +28,7 @@ def get_abl_line_number(repo_name):
     return 1
 
 
-def get_book_metadata(repo_name, slug, version="main"):
+def get_book_metadata(repo_name, version="main"):
     owner = "openstax"
     repos_url = f"https://api.github.com/repos/{owner}"
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -498,7 +498,7 @@ export default {
       setTimeout(() => { this.getJobsImmediate() }, 1000)
     },
     async newABLentry (item) {
-      const { repo, slug } = this.collectionParts(item)
+      const { repo } = this.collectionParts(item)
       const [owner, repoName] = repo.split('/')
       if (owner !== 'openstax') {
         const errMsg = 'Only Openstax repositories can be added to the ABL at this time'
@@ -506,7 +506,7 @@ export default {
         throw new Error(errMsg)
       }
       const version = this.ref(item)
-      const ablData = await this.$axios.$get(`/api/abl/${repoName}/${slug}/${version}`)
+      const ablData = await this.$axios.$get(`/api/abl/${repoName}/${version}`)
 
       // What goes inside the versions array
       const versionEntry = {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -508,27 +508,28 @@ export default {
       const version = this.ref(item)
       const ablData = await this.$axios.$get(`/api/abl/${repoName}/${slug}/${version}`)
 
-      const ablEntry = {
-        repository_name: repoName,
-        platforms: ['REX'],
-        versions: [
-          {
-            min_code_version: null,  // To be filled in manually
-            edition: null,  // To be filled in manually
-            commit_sha: ablData.commit_sha,
-            commit_metadata: {
-              committed_at: ablData.committed_at,
-              books: [
-                {
-                  style: ablData.style,
-                  uuid: ablData.uuid,
-                  slug
-                }
-              ]
-            }
-          }
-        ]
+      // What goes inside the versions array
+      const versionEntry = {
+        min_code_version: null,  // To be filled in manually
+        edition: null,  // To be filled in manually
+        commit_sha: ablData.commit_sha,
+        commit_metadata: {
+          committed_at: ablData.committed_at,
+          books: ablData.books
+        }
       }
+
+      // Line number is 1 for new ABL entries
+      const ablEntry = ablData.line_number === 1
+        ? {
+            repository_name: repoName,
+            platforms: ['REX'],
+            versions: [
+              versionEntry
+            ]
+          } 
+        : versionEntry
+      
       await navigator.clipboard.writeText(JSON.stringify(ablEntry, null, 2))
       window.open(`https://github.com/openstax/content-manager-approved-books/edit/main/approved-book-list.json#L${ablData.line_number}`, '_blank')
     },


### PR DESCRIPTION
- [ ] openstax/ce#1834

Fixes tags not working and books missing from ABL version entry.

Removed `slug` path argument since metadata should be returned for all book slugs. 

Changed value written to clipboard: it used to create a new ABL entry, now it will create a version entry (which can be pasted into the versions array) if the ABL entry already exists. 