### PR TITLE
Un-hide the TOC in the index of Sphinx docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,9 +14,12 @@ produce OpenStax book artifacts for Content Managers (CMs),
 QA, and developers. CORGI is used to create, monitor, and 
 display the status of content production tasks. 
 
+*****************
+Table of Contents
+*****************
+
 .. toctree::
-   :maxdepth: 2
-   :hidden:
+   :maxdepth: 3
 
    operations/setting_up_the_swarm
    operations/generate_pipeline_config
@@ -25,7 +28,6 @@ display the status of content production tasks.
 .. toctree::
    :maxdepth: 2
    :caption: Extras
-   :hidden:
 
    glossary
 


### PR DESCRIPTION
This is a simple PR to make the contents of the docs easier to navigate and view. It's been on my list for a while. I wanted to add the TOC, but it was already there. It was hidden.