### PR TITLE
Fix typo in deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,7 +17,7 @@ STACK_NAME=${STACK_NAME} \
 TAG=${TAG} \
 REVISION=${REVISION} \
 DEPLOYED_AT=${DEPLOYED_AT} \
-SUBNET=${SUBNET}
+SUBNET=${SUBNET} \
 docker-compose \
 -f docker-compose.stack.release.yml \
 config > docker-stack.yml


### PR DESCRIPTION
An unfortunate typo. I forgot the line continuation `\` while adding subnets. I wish I had noticed it earlier. On the bright side, I noticed it before it caused a problem.