### PR TITLE
2025 - Build frontend and backend during CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
 
   build-backend:
     docker:
-      - image: cimg/base:2023.02
+      - image: cimg/base:stable
 
     steps:
       - checkout
@@ -50,8 +50,11 @@ jobs:
       - run:
           name: Build backend image
           command: |
-            cd ./backend
-            docker build -f backend.dockerfile --target prod-runner .
+            diff="$(git diff --name-only ${CIRCLE_SHA1} || git diff --name-only main)"
+            if echo "$diff" | grep "backend/" > /dev/null; then
+              cd ./backend
+              docker build -f backend.dockerfile --target prod-runner .
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  shellcheck: circleci/shellcheck@1.3.16
+  shellcheck: circleci/shellcheck@3.1.2
   python: circleci/python@2.0.3
 jobs:
   frontend-unit:
@@ -14,6 +14,7 @@ jobs:
           command: |
             cd ./frontend
             npm ci
+            npm run build
             npm run test:unit
   
   backend-unit:
@@ -27,7 +28,6 @@ jobs:
       - run:
           name: Run unit tests
           command: |
-
             cd ./backend/app
             poetry install --no-root --no-interaction --no-ansi
             poetry run pytest -vvv --junitxml=/tmp/test-reports/junit.xml ./tests/unit
@@ -39,11 +39,35 @@ jobs:
       - store_test_results:
           path: /tmp/test-reports
 
+  build-backend:
+    docker:
+      - image: cimg/base:2023.02
+
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build backend image
+          command: |
+            cd ./backend
+            docker build -f backend.dockerfile --target prod-runner .
+
 workflows:
   version: 2
   run-tests:
     jobs:
+      - shellcheck/check:
+          dir: ./scripts
+          pattern: "*.sh"
+          exclude: SC1091
+      - shellcheck/check:
+          dir: ./backend/app/bin
+          pattern: "*.sh"
+          exclude: SC1091
+      - shellcheck/check:
+          dir: "."
+          pattern: corgi
       - frontend-unit
       - backend-unit
-      - shellcheck/check:
-          path: ./
+      - build-backend

--- a/corgi
+++ b/corgi
@@ -3,11 +3,11 @@
 set -eo pipefail
 
 log() {
-    echo $* >&2
+    echo "$@" >&2
 }
 
 die() {
-    log $*
+    log "$@"
     exit 1
 }
 
@@ -34,7 +34,7 @@ The commands are:
 EOF
 
     if [[ -n "$1" ]]; then
-        log $*
+        log "$@"
     fi
     exit 1
 }
@@ -76,7 +76,7 @@ elif [[ "$COMMAND" == "build" || "$COMMAND" == "restart" ]]; then
         docker-compose -f "$dev_stack" -f "$leash_stack" "$COMMAND"
     fi
 elif [[ "$COMMAND" == "logs" ]]; then
-    docker-compose -f "$dev_stack" logs $*
+    docker-compose -f "$dev_stack" logs "$@"
 elif [[ "$COMMAND" == "stop" ]]; then
     docker-compose -f "$dev_stack" down
 elif [[ "$COMMAND" == "create-jobs" ]]; then

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -3,6 +3,7 @@
 # Exit in case of error
 set -e
 
+# shellcheck source=SCRIPTDIR/build.sh
 FRONTEND_ENV=${FRONTEND_ENV-production} \
 source ./scripts/build.sh
 


### PR DESCRIPTION
- [ ] openstax/ce#2025

Small update:
1. Build the frontend bundle before running unit tests so that we know it will build if a PR is merged.
2. Build the backend docker image so that we know it will build if a PR is merged.
3. Fix shellcheck checks. This fix would have prevented the typo I merged to main about a week ago. [SC1091](https://www.shellcheck.net/wiki/SC1090) is excluded because all the scripts that are sourced are being checked anyway.