### PR TITLE
Add updateImmediate to RateLimited

### DIFF
--- a/frontend/src/components/JobsTable.svelte
+++ b/frontend/src/components/JobsTable.svelte
@@ -310,7 +310,7 @@
     );
     setTimeout(async () => {
       await Promise.all([
-        jobsStore.update(),
+        jobsStore.updateImmediate(),
         repoSummariesStore.update()
       ])
     }, 1 * SECONDS);

--- a/frontend/src/ts/stores.ts
+++ b/frontend/src/ts/stores.ts
@@ -46,6 +46,8 @@ const RateLimited = <T extends Updatable>(
     }
   }
 
+  public updateImmediate = super.update
+
   public clearLimit() {
     this.nextUpdate = 0
   }


### PR DESCRIPTION
jobStore.update is subject to rate limiting. We want jobs to update immediately after the user submits a job. I added a way to sidestep rate limits via updateImmediate.

This would fix the problem, but it raises the question if the jobs store benefits from rate limiting at all.