### PR TITLE
Make book field optional

### DIFF
--- a/backend/app/app/service/jobs.py
+++ b/backend/app/app/service/jobs.py
@@ -92,9 +92,6 @@ class JobsService(ServiceBase):
         if repo_book_in is not None:
             if not any(b["slug"] == repo_book_in for b in repo_books):
                 raise CustomBaseError(f"Book not in repository '{repo_book_in}'")
-        else:
-            # Until we can build multiple books
-            raise CustomBaseError("Book is required")
 
         async def insert_job():
             commit = cast(Optional[Commit], db.query(Commit).filter(

--- a/frontend/src/components/JobsTable.svelte
+++ b/frontend/src/components/JobsTable.svelte
@@ -300,8 +300,10 @@
             <Wrapper>
               {#if isJobComplete(item)}
                 <a
-                  href={item.artifact_urls.find(a => a.url != null)?.url ?? ''}
-                  target="_blank"
+                  href={item.books.length === 1
+                    ? item.artifact_urls[0].url
+                    : `#${item.id}`}
+                  target={item.books.length === 1 ? "_blank" : "_self"}
                   rel="noreferrer"
                 >
                   <img
@@ -386,8 +388,10 @@
           </Cell>
           <Cell class="lg">
             <Wrapper>
-              <span class="table-text worker-version">{item.worker_version || '(pending)'}</span>
-              <Tooltip>{item.worker_version || '(pending)'}</Tooltip>
+              <span class="table-text worker-version"
+                >{item.worker_version || "(pending)"}</span
+              >
+              <Tooltip>{item.worker_version || "(pending)"}</Tooltip>
             </Wrapper>
           </Cell>
           <Cell>

--- a/frontend/src/components/JobsTable.svelte
+++ b/frontend/src/components/JobsTable.svelte
@@ -300,7 +300,7 @@
             <Wrapper>
               {#if isJobComplete(item)}
                 <a
-                  href={item.artifact_urls[0].url}
+                  href={item.artifact_urls.find(a => a.url != null)?.url ?? ''}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/frontend/src/components/NewJobForm.svelte
+++ b/frontend/src/components/NewJobForm.svelte
@@ -115,8 +115,7 @@
 
   $: validJob =
     selectedJobTypes.length !== 0 &&
-    !!selectedRepo?.trim() &&
-    !!selectedBook?.trim();
+    !!selectedRepo?.trim()
   $: void setSelectedRepo(selectedBook);
 </script>
 

--- a/frontend/src/ts/jobs.ts
+++ b/frontend/src/ts/jobs.ts
@@ -52,7 +52,7 @@ export function repeatJob(job: Job) {
   void submitNewJob(
     job.job_type_id,
     repoToString(job.repository),
-    job.books[0].slug,
+    job.books.length === 1 ? job.books[0].slug : null,
     job.git_ref
   );
 }


### PR DESCRIPTION
fixes openstax/ce#2019
depends on openstax/enki/pull/282

This makes the book field optional. When the book slug is not supplied, all books in the repository are built. If a book slug is supplied, only that book slug is attached to the job. 