### PR TITLE
Transform relative source links into GitHub links

### DIFF
--- a/corgi
+++ b/corgi
@@ -129,7 +129,18 @@ async def main():
             job_id = job["id"]
             update_args = {"status_id": str(status_id)}
             if status_id == 4:
-                update_args["error_message"] = "+ Trace line\\n+ Trace line 2\\nJust testing\\n1\\n2\\n3"
+                update_args["error_message"] = "\n".join((
+                    "+ Trace line",
+                    "+ Trace line 2",
+                    "Just testing",
+                    "1",
+                    "2",
+                    "3",
+                    "Error ./modules/m123/index.cnxml:3:1 <!-- here and ./modules/m123/index.cnxml:3:1 <-- here",
+                    "<a href=\"escaped\">Should-not-work</a>",
+                    "Error ./collections/book-slug1.collection.xml:3:1 <!-- here",
+                    "No link ./media/something.jpg <-- here"
+                ))
             elif status_id == 5:
                 update_args["artifact_urls"] = [
                     {

--- a/frontend/src/components/NewJobForm.svelte
+++ b/frontend/src/components/NewJobForm.svelte
@@ -113,9 +113,7 @@
     });
   });
 
-  $: validJob =
-    selectedJobTypes.length !== 0 &&
-    !!selectedRepo?.trim()
+  $: validJob = selectedJobTypes.length !== 0 && !!selectedRepo?.trim();
   $: void setSelectedRepo(selectedBook);
 </script>
 

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -143,3 +143,8 @@ export async function newABLentry(job: Job) {
     "_blank"
   );
 }
+
+// https://stackoverflow.com/a/22706073
+export function escapeHTML(str: string) {
+  return new Option(str).innerHTML;
+}


### PR DESCRIPTION
Once Enki error messages include the source map links, it would be nice if those linked to the source line on GitHub. 

Steps:
1. Escape any html in the error message
2. Replace **relative** source links (i.e. `./<anything>.cnxml:<line>:<col>`) with anchor tags that link to the source on GitHub
3. Split on line feed
4. In the dialog, interpret each line as html with `@html`