### PR TITLE
Order book and job relationship by book id

### DIFF
--- a/backend/app/app/db/schema.py
+++ b/backend/app/app/db/schema.py
@@ -34,7 +34,12 @@ class Jobs(Base):
     status = relationship("Status", back_populates="jobs", lazy="joined")
     job_type = relationship("JobTypes", back_populates="jobs", lazy="joined")
     user = relationship("User", back_populates="jobs", lazy="joined")
-    books = relationship("BookJob", back_populates="job", lazy="joined")
+    books = relationship(
+        "BookJob",
+        back_populates="job",
+        lazy="joined",
+        order_by="asc(BookJob.book_id)",
+    )
 
 
 class Status(Base):


### PR DESCRIPTION
fixes openstax/ce#2124

The UI tests should be enough to test this change. No changes to content generation.

# Summary

Add explicit order_by for book_id so that books should always appear in the order they were inserted in. Right now, the order they are inserted in is based on the order they are defined in within the books.xml.