### PR TITLE
Fix timezone

### DIFF
--- a/backend/app/app/api/endpoints/jobs.py
+++ b/backend/app/app/api/endpoints/jobs.py
@@ -89,7 +89,7 @@ def list_jobs(
             Job.from_orm(j)
             for j in jobs_service.get_jobs_in_date_range(
                 db,
-                datetime.fromtimestamp(range_start),
+                datetime.fromtimestamp(range_start, timezone.utc),
                 now,
                 order_by=[jobs_service.schema_model.id.asc()],
             )

--- a/backend/app/app/db/schema.py
+++ b/backend/app/app/db/schema.py
@@ -15,12 +15,16 @@ class DateTimeUTC(sa.types.TypeDecorator):
     cache_ok = True
 
     def process_bind_param(self, value, dialect):
-        if isinstance(value, datetime):
-            if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
-                raise TypeError("Timezone is required")
+        # If the value does not have a timezone, it is assumed to be utc
+        if (
+            isinstance(value, datetime)
+            and value.tzinfo is not None
+            and value.tzinfo.utcoffset(value) is not None
+        ):
             # Convert the time to utc (requires timezone), then remove timezone
             # The timezone is implicitly removed when the datetime is stored
             value = value.astimezone(timezone.utc).replace(tzinfo=None)
+
         return value
 
     def process_result_value(self, value, dialect):

--- a/backend/app/app/db/schema.py
+++ b/backend/app/app/db/schema.py
@@ -15,15 +15,15 @@ class DateTimeUTC(sa.types.TypeDecorator):
     cache_ok = True
 
     def process_bind_param(self, value, dialect):
-        # If the value does not have a timezone, it is assumed to be utc
-        if (
-            isinstance(value, datetime)
-            and value.tzinfo is not None
-            and value.tzinfo.utcoffset(value) is not None
+        # Convert values to utc or fail
+        if isinstance(value, datetime) and (
+            value.tzinfo is None or value.tzinfo.utcoffset(value) is None
         ):
-            # Convert the time to utc (requires timezone), then remove timezone
-            # The timezone is implicitly removed when the datetime is stored
-            value = value.astimezone(timezone.utc).replace(tzinfo=None)
+            raise TypeError("tzinfo is required")
+
+        # Convert the time to utc (requires timezone), then remove timezone
+        # The timezone is implicitly removed when the datetime is stored
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
 
         return value
 

--- a/backend/app/app/db/schema.py
+++ b/backend/app/app/db/schema.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship
@@ -6,18 +6,25 @@ from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 
 
+def utcnow():
+    return datetime.now(timezone.utc)
+
+
 class JobTypes(Base):
     id = sa.Column(sa.Integer, primary_key=True, index=True)
     name = sa.Column(sa.String, nullable=False)
     display_name = sa.Column(sa.String, nullable=False)
     created_at = sa.Column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, index=True
+        sa.DateTime,
+        nullable=False,
+        default=utcnow,
+        index=True,
     )
     updated_at = sa.Column(
         sa.DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
     )
 
     jobs = relationship("Jobs", back_populates="job_type")
@@ -32,13 +39,16 @@ class Jobs(Base):
     worker_version = sa.Column(sa.String)
     error_message = sa.Column(sa.String)
     created_at = sa.Column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, index=True
+        sa.DateTime,
+        nullable=False,
+        default=utcnow,
+        index=True,
     )
     updated_at = sa.Column(
         sa.DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
     )
 
     status = relationship("Status", back_populates="jobs", lazy="joined")
@@ -55,12 +65,12 @@ class Jobs(Base):
 class Status(Base):
     id = sa.Column(sa.Integer, primary_key=True, index=True)
     name = sa.Column(sa.String)
-    created_at = sa.Column(sa.DateTime, default=datetime.utcnow, index=True)
+    created_at = sa.Column(sa.DateTime, default=utcnow, index=True)
     updated_at = sa.Column(
         sa.DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         index=True,
     )
 
@@ -113,12 +123,12 @@ class Book(Base):
 class CodeVersion(Base):
     id = sa.Column(sa.Integer, primary_key=True, index=True)
     version = sa.Column(sa.String, nullable=False)
-    created_at = sa.Column(sa.DateTime, default=datetime.utcnow, index=True)
+    created_at = sa.Column(sa.DateTime, default=utcnow, index=True)
     updated_at = sa.Column(
         sa.DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         index=True,
     )
 
@@ -130,12 +140,12 @@ class CodeVersion(Base):
 class Consumer(Base):
     id = sa.Column(sa.Integer, primary_key=True, index=True)
     name = sa.Column(sa.String, nullable=False)
-    created_at = sa.Column(sa.DateTime, default=datetime.utcnow, index=True)
+    created_at = sa.Column(sa.DateTime, default=utcnow, index=True)
     updated_at = sa.Column(
         sa.DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         index=True,
     )
 
@@ -156,12 +166,12 @@ class ApprovedBook(Base):
         index=True,
         primary_key=True,
     )
-    created_at = sa.Column(sa.DateTime, default=datetime.utcnow, index=True)
+    created_at = sa.Column(sa.DateTime, default=utcnow, index=True)
     updated_at = sa.Column(
         sa.DateTime,
         nullable=False,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utcnow,
+        onupdate=utcnow,
         index=True,
     )
 

--- a/backend/app/migrations/versions/0eee70848f87_add_seed_data_for_git_job_types.py
+++ b/backend/app/migrations/versions/0eee70848f87_add_seed_data_for_git_job_types.py
@@ -6,7 +6,7 @@ Create Date: 2020-11-05 20:34:27.770606
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -29,7 +29,7 @@ jobs_table = sa.table("jobs", sa.column("job_type_id"))
 
 
 def upgrade():
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
     server_data = [
         {
             "id": 3,

--- a/backend/app/migrations/versions/14c3c7f3115e_add_aborted_state_seed_data.py
+++ b/backend/app/migrations/versions/14c3c7f3115e_add_aborted_state_seed_data.py
@@ -6,7 +6,7 @@ Create Date: 2021-01-13 23:14:38.997558
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -28,7 +28,7 @@ status_table = sa.table(
 
 
 def upgrade():
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
     bind = op.get_bind()
 
     status_data = [

--- a/backend/app/migrations/versions/2837298015bf_added_content_servers_table.py
+++ b/backend/app/migrations/versions/2837298015bf_added_content_servers_table.py
@@ -6,7 +6,7 @@ Create Date: 2019-10-21 15:52:38.549364
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -56,7 +56,7 @@ def upgrade():
         None, "events", "content_servers", ["content_server_id"], ["id"]
     )
 
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
 
     server_data = [
         {

--- a/backend/app/migrations/versions/3e801ba4d7e0_add_approved_book_table_and_child_tables.py
+++ b/backend/app/migrations/versions/3e801ba4d7e0_add_approved_book_table_and_child_tables.py
@@ -6,7 +6,7 @@ Create Date: 2024-02-26 20:13:21.678327
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -18,7 +18,7 @@ branch_labels = None
 depends_on = None
 
 
-utcnow = datetime.utcnow()
+utcnow = datetime.now(timezone.utc)
 consumer_table = sa.table(
     "consumer",
     sa.column("id", sa.Integer),

--- a/backend/app/migrations/versions/55eae8bd7f1e_initial_schema.py
+++ b/backend/app/migrations/versions/55eae8bd7f1e_initial_schema.py
@@ -6,7 +6,7 @@ Create Date: 2019-10-09 20:59:21.799403
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -64,7 +64,7 @@ def upgrade():
     )
     op.create_index(op.f("ix_events_id"), "events", ["id"], unique=False)
     # ### end Alembic commands ###
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
 
     status_data = [
         {"name": "queued", "created_at": utcnow, "updated_at": utcnow},

--- a/backend/app/migrations/versions/603c41a55f80_add_epub_job_type.py
+++ b/backend/app/migrations/versions/603c41a55f80_add_epub_job_type.py
@@ -6,7 +6,7 @@ Create Date: 2023-02-07 19:34:05.500073
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -32,7 +32,7 @@ epub_type_id = 6
 
 
 def upgrade():
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
     server_data = [
         {
             "id": epub_type_id,

--- a/backend/app/migrations/versions/b1a7843ab462_add_seed_entries_to_content_servers.py
+++ b/backend/app/migrations/versions/b1a7843ab462_add_seed_entries_to_content_servers.py
@@ -6,7 +6,7 @@ Create Date: 2020-12-22 19:11:43.657348
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -30,7 +30,7 @@ content_servers_table = sa.table(
 
 def upgrade():
     bind = op.get_bind()
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
     server_data = [
         {
             "name": "production",

--- a/backend/app/migrations/versions/cc7ec89e9135_added_jobs_types_table_and_foreign_key_.py
+++ b/backend/app/migrations/versions/cc7ec89e9135_added_jobs_types_table_and_foreign_key_.py
@@ -6,7 +6,7 @@ Create Date: 2020-09-08 14:39:19.852731
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -42,7 +42,7 @@ def upgrade():
         op.f("ix_jobs_job_type"), "jobs", ["job_type_id"], unique=False
     )
 
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
 
     server_data = [
         {"id": 1, "name": "pdf", "created_at": utcnow, "updated_at": utcnow},

--- a/backend/app/migrations/versions/dd5b4a5068a6_add_docx_job_type_to_job_types.py
+++ b/backend/app/migrations/versions/dd5b4a5068a6_add_docx_job_type_to_job_types.py
@@ -6,7 +6,7 @@ Create Date: 2022-07-25 14:38:25.831153
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 from alembic import op
@@ -30,7 +30,7 @@ jobs_table = sa.table("jobs", sa.column("job_type_id"))
 
 
 def upgrade():
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(timezone.utc)
     server_data = [
         {
             "id": 5,

--- a/frontend/specs/jobs.spec.ts
+++ b/frontend/specs/jobs.spec.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it, jest, beforeEach } from "@jest/globals";
 import { submitNewJob, abortJob } from "../src/ts/jobs";
 import * as jobs from "../src/ts/jobs";
-import { repoToString, parseDateTimeAsUTC } from "../src/ts/utils";
+import { repoToString, parseDateTime } from "../src/ts/utils";
 import { jobsStore, updateRunningJobs } from "../src/ts/stores";
 import type { Job } from "../src/ts/types";
 import { jobFactory } from "./spec-helpers";
@@ -99,7 +99,7 @@ describe("updateRunningJobs", () => {
     await updateRunningJobs(jobs);
 
     expect(getJobsMock).toHaveBeenCalledWith(
-      parseDateTimeAsUTC(jobs[1].created_at) / 1000,
+      parseDateTime(jobs[1].created_at) / 1000,
     );
   });
 });

--- a/frontend/src/components/JobsTable.svelte
+++ b/frontend/src/components/JobsTable.svelte
@@ -7,8 +7,8 @@
     handleError,
     repoToString,
     readableDateTime,
-    parseDateTimeAsUTC,
-    isJobComplete,
+    parseDateTime,
+    isJobComplete
   } from "../ts/utils";
   import NewJobForm from "./NewJobForm.svelte";
   import { submitNewJob } from "../ts/jobs";
@@ -31,7 +31,7 @@
   import type { Job, JobType } from "../ts/types";
   import DetailsDialog from "./DetailsDialog.svelte";
   import { MINUTES, SECONDS } from "../ts/time";
-    import { hasABLEntry } from "../ts/abl";
+  import { hasABLEntry } from "../ts/abl";
 
   let statusStyles = {
     queued: "filter-yellow",
@@ -100,7 +100,7 @@
     let cssClasses = `job-status-icon ${statusStyles[statusName]}`;
     if (
       statusName === "completed" &&
-      Date.now() - parseDateTimeAsUTC(job.updated_at) < 30 * SECONDS
+      Date.now() - parseDateTime(job.updated_at) < 30 * SECONDS
     ) {
       cssClasses += " bounce";
     }
@@ -305,7 +305,7 @@
       {#each slice as item (item.id)}
         <!-- <DetailRow> -->
         {@const isApproved = hasABLEntry($ABLStore, item)}
-        <Row slot="data" class={isApproved ? 'abl' : ''}>
+        <Row slot="data" class={isApproved ? "abl" : ""}>
           <Cell>
             <Button
               on:click={() => {

--- a/frontend/src/ts/abl.ts
+++ b/frontend/src/ts/abl.ts
@@ -1,7 +1,7 @@
 import { RequireAuth } from "./fetch-utils";
 import type { Job, Book, ApprovedBookWithDate } from "./types";
 import { handleError } from "./utils";
-import { parseDateTimeAsUTC } from "./utils";
+import { parseDateTime } from "./utils";
 
 export async function newABLentry(job: Job, codeVersion: string) {
   const entries = job.books.map((b) => ({
@@ -35,10 +35,7 @@ export function getLatestCodeVersionForBook(
 ) {
   const latestEntry = abl
     .filter((entry) => entry.uuid === book.uuid)
-    .sort(
-      (b, a) =>
-        parseDateTimeAsUTC(a.created_at) - parseDateTimeAsUTC(b.created_at),
-    );
+    .sort((b, a) => parseDateTime(a.created_at) - parseDateTime(b.created_at));
   return latestEntry[0]?.code_version;
 }
 

--- a/frontend/src/ts/stores.ts
+++ b/frontend/src/ts/stores.ts
@@ -2,7 +2,7 @@ import { derived, Readable, writable } from "svelte/store";
 import { getJobs } from "./jobs";
 import { SECONDS } from "./time";
 import type { ApprovedBookWithDate, Job, RepositorySummary } from "./types";
-import { fetchRepoSummaries, isJobComplete, parseDateTimeAsUTC } from "./utils";
+import { fetchRepoSummaries, isJobComplete, parseDateTime } from "./utils";
 import { fetchABL } from "./abl";
 
 type GConstructor<T = object> = new (...args: any[]) => T;
@@ -164,7 +164,7 @@ export async function updateRunningJobs(jobs: Job[]): Promise<Job[]> {
 
   for (let i = jobs.length - 1; i >= 0; i--) {
     const j = jobs[i];
-    if (parseDateTimeAsUTC(j.updated_at) < searchRangeStartTimestamp) {
+    if (parseDateTime(j.updated_at) < searchRangeStartTimestamp) {
       break;
     }
     if (!isJobComplete(j)) {
@@ -176,7 +176,7 @@ export async function updateRunningJobs(jobs: Job[]): Promise<Job[]> {
     oldestRunningJobIndex === -1 ? jobs.length - 1 : oldestRunningJobIndex;
 
   const lastJob = jobs[lastJobIndex];
-  const rangeStart = parseDateTimeAsUTC(lastJob.created_at) / 1000;
+  const rangeStart = parseDateTime(lastJob.created_at) / 1000;
   const newJobs = await getJobs(rangeStart);
   if (newJobs.length === 0) {
     return jobs;

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -3,7 +3,7 @@ import { RequireAuth } from "./fetch-utils";
 import { errorStore } from "./stores";
 import { MINUTES, HOURS, DAYS } from "./time";
 
-type Errors = Error;
+interface Errors extends Error {}
 
 export function handleError(e: Errors) {
   errorStore.add(e.toString());
@@ -44,7 +44,7 @@ export function filterBooks(
 }
 
 export function readableDateTime(datetime: string): string {
-  return new Date(parseDateTimeAsUTC(datetime)).toLocaleString();
+  return new Date(parseDateTime(datetime)).toLocaleString();
 }
 
 export function mapImage(folder: string, name: string, type: string): string {
@@ -64,18 +64,13 @@ export function parseDateTimeAddTZ(dateTime: string, tzOffset: string) {
   return Date.parse(dateTime + tzOffset);
 }
 
-export function parseDateTimeAsUTC(dateTime: string) {
-  // The database engine we are using does not seem to support storing timezone.
-  // We store UTC times in the database. Adding the UTC offset here makes
-  // javascript parse the time using UTC timezone instead of local timezone.
-  return parseDateTimeAddTZ(dateTime, "+00:00");
-}
+export const parseDateTime = Date.parse;
 
 export function calculateElapsed(job: Job): string {
   const update_time = isJobComplete(job)
-    ? parseDateTimeAsUTC(job.updated_at)
+    ? parseDateTime(job.updated_at)
     : Date.now();
-  const start_time = parseDateTimeAsUTC(job.created_at);
+  const start_time = parseDateTime(job.created_at);
   const elapsed = (update_time - start_time) / 1000;
   const hours = Math.floor(elapsed / 3600)
     .toString()
@@ -86,7 +81,7 @@ export function calculateElapsed(job: Job): string {
 }
 
 export function calculateAge(job: Job): string {
-  const start_time = parseDateTimeAsUTC(job.created_at);
+  const start_time = parseDateTime(job.created_at);
   const elapsed = Date.now() - start_time;
   const toCheck: Array<[number, string]> = [
     [DAYS, "days"],


### PR DESCRIPTION
Use custom SQLAlchemy type to ensure utc tz

Ensure stored values are converted to timezone-naive datetimes with utc offset. datetimes have always been stored in the database with an assumed utc offset.

This change makes the aforementioned assumption more explicit and adds support for converting datetimes from other timezones.