### PR TITLE
Update ruff config

### DIFF
--- a/backend/app/.ruff.toml
+++ b/backend/app/.ruff.toml
@@ -1,5 +1,16 @@
 line-length = 80
 
+exclude = [
+    ".tox",
+    ".git",
+    ".venv",
+    ".env",
+    "build*.py"
+]
+
+[lint.mccabe]
+max-complexity = 18
+
 [lint]
 select = [
     # pycodestyle
@@ -10,10 +21,13 @@ select = [
     "UP",
     # flake8-bugbear
     "B",
+    # McCabe complexity
+    "C",
     # flake8-simplify
     "SIM",
     # isort
     "I",
+    "W"
 ]
 ignore = ["F401", "B008", "B006", "UP022"]
 fixable = ["ALL"]

--- a/backend/app/.ruff.toml
+++ b/backend/app/.ruff.toml
@@ -32,6 +32,15 @@ select = [
 ignore = ["F401", "B008", "B006", "UP022"]
 fixable = ["ALL"]
 
+[lint.isort]
+known-local-folder = ["app", "tests"]
+section-order = [
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder",
+]
+
 [format]
 quote-style = "double"
 indent-style = "space"

--- a/backend/app/app/data_models/models.py
+++ b/backend/app/app/data_models/models.py
@@ -138,7 +138,7 @@ class RepositoryGetter(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
         repository = self._obj
         if key == "books":
-            books = set([])
+            books = set()
             for commit in repository.commits:
                 for book in commit.books:
                     books.add(book.slug)

--- a/backend/app/setup.cfg
+++ b/backend/app/setup.cfg
@@ -1,15 +1,3 @@
 [tool:pytest]
 addopts=-vvvs --tb=long --showlocals
 xfail_strict=true
-
-[flake8]
-max-line-length=100
-ignore = E203, E266, E501, W503, F403, F401
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-exclude =
-	.tox,
-	.git,
-	.venv,
-	.env,
-	build*.py

--- a/backend/app/tests/.ruff.toml
+++ b/backend/app/tests/.ruff.toml
@@ -1,0 +1,4 @@
+extend = "../.ruff.toml"
+
+[lint]
+ignore = ["E203", "E266", "E501", "F403", "F401"]

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,5 +1,3 @@
-# ruff: noqa: E501
-
 import os
 import re
 

--- a/backend/app/tests/ui/pages/home.py
+++ b/backend/app/tests/ui/pages/home.py
@@ -1,5 +1,3 @@
-# ruff: noqa: E501
-
 from enum import Enum
 from time import sleep, time
 

--- a/backend/app/tests/ui/test_create_new_job_button.py
+++ b/backend/app/tests/ui/test_create_new_job_button.py
@@ -1,5 +1,3 @@
-# ruff: noqa: E501
-
 import pytest
 from pytest_testrail.plugin import pytestrail
 

--- a/backend/app/tests/ui/test_e2e_pdf_jobs.py
+++ b/backend/app/tests/ui/test_e2e_pdf_jobs.py
@@ -1,5 +1,3 @@
-# ruff: noqa: E501
-
 import io
 from urllib.request import Request, urlopen
 

--- a/backend/app/tests/ui/test_multiple_error_messages.py
+++ b/backend/app/tests/ui/test_multiple_error_messages.py
@@ -1,5 +1,3 @@
-# ruff: noqa: E501
-
 import pytest
 from pytest_testrail.plugin import pytestrail
 

--- a/backend/app/tests/ui/test_single_error_messages.py
+++ b/backend/app/tests/ui/test_single_error_messages.py
@@ -1,5 +1,3 @@
-# ruff: noqa: E501
-
 import pytest
 from pytest_testrail.plugin import pytestrail
 

--- a/corgi
+++ b/corgi
@@ -193,10 +193,11 @@ elif [[ "$COMMAND" == "lint" ]]; then
     docker compose -f "$dev_stack" run --rm backend ruff check
     docker compose -f "$dev_stack" run --rm backend ruff format --check
     docker compose -f "$dev_stack" run --rm frontend npm run lint
-elif [[ "$COMMAND" == "format" ]]; then
+elif [[ "$COMMAND" == "format" ]]; then (
+    set +e
     docker compose -f "$dev_stack" run --rm backend ruff check --fix
     docker compose -f "$dev_stack" run --rm backend ruff format
     docker compose -f "$dev_stack" run --rm frontend npm run format
-else
+) else
     usage "Unknown command \"$COMMAND\""
 fi


### PR DESCRIPTION
It should enforce the line length limit everywhere except tests. The ignored rules in the .ruff.toml file located in the tests directory should only be ignored within that directory and its subdirectories. [Here’s the documentation.](https://docs.astral.sh/ruff/configuration/#config-file-discovery)