### PR TITLE
2227 rex version for new books

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,13 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[svelte]": {
-    "editor.defaultFormatter": "svelte.svelte-vscode"
-  }
+    "editor.defaultFormatter": "svelte.svelte-vscode",
+    "editor.detectIndentation": false,
+    "editor.tabSize": 2
+  },
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "ruff.format.args": ["--config", "./backend/app/.ruff.toml"],
+  "ruff.lint.args": ["--config", "./backend/app/.ruff.toml"],
 }

--- a/frontend/specs/abl.spec.ts
+++ b/frontend/specs/abl.spec.ts
@@ -91,12 +91,13 @@ describe("newABLentry", () => {
     it(`calls fetch with the correct information -> ${args}`, async () => {
       const { job, code_version: codeVersion, expected } = args;
       await newABLentry(job, codeVersion);
-      const url: string = (fetchSpy.mock.lastCall as any[])[0] as string;
-      const options = (fetchSpy.mock.lastCall as any[])[1];
-      const body = JSON.parse(options.body);
+      const url = fetchSpy.mock.lastCall?.[0];
+      const options = fetchSpy.mock.lastCall?.[1];
+      const body = JSON.parse(options?.body?.toString() ?? "{}");
+      expect(url).toBeDefined();
       expect(errors[0]).toBeUndefined();
-      expect(options.method).toBe("POST");
-      expect(options.headers["Content-Type"]).toBe("application/json");
+      expect(options?.method).toBe("POST");
+      expect(options?.headers?.["Content-Type"]).toBe("application/json");
       expect(url).toBe("/api/abl/");
       expect(body).toStrictEqual(expected);
     });
@@ -191,7 +192,7 @@ describe("fetchABL", () => {
   it("fetches the ABL without error", async () => {
     mockJSONResponse(fetchSpy, []);
     const value = await fetchABL();
-    const url: string = (fetchSpy.mock.lastCall as any[])[0] as string;
+    const url = fetchSpy.mock.lastCall?.[0];
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(errors[0]).toBeUndefined();
     expect(url).toBe("/api/abl/");
@@ -211,7 +212,7 @@ describe("fetchRexReleaseVersion", () => {
   it("fetches the REX release version without error", async () => {
     mockJSONResponse(fetchSpy, { version: "test-version" });
     const version = await fetchRexReleaseVersion();
-    const url: string = (fetchSpy.mock.lastCall as any[])[0] as string;
+    const url = fetchSpy.mock.lastCall?.[0];
     expect(errors[0]).toBeUndefined();
     expect(url).toMatch(/rex-release-version/);
     expect(version).toBe("test-version");

--- a/frontend/specs/abl.spec.ts
+++ b/frontend/specs/abl.spec.ts
@@ -17,8 +17,7 @@ import {
   hasABLEntry,
   newABLentry,
 } from "../src/ts/abl";
-import * as stores from "../src/ts/stores";
-import { errorStore } from "../src/ts/stores";
+import { errorStore, REXVersionStore } from "../src/ts/stores";
 import {
   Fetch,
   approvedBookWithDateFactory,
@@ -236,23 +235,26 @@ describe("fetchRexReleaseVersion", () => {
 });
 
 describe("getRexReleaseVersion", () => {
-  const { REXVersionStore } = stores;
   let updateImmediateSpy: jest.SpiedFunction<() => Promise<void>>;
   let updateSpy: jest.SpiedFunction<() => Promise<void>>;
+  // @ts-expect-error baseStore is protected but the test is made reasonably
+  // more realistic by violating this visibility rule
+  const baseStore = REXVersionStore.baseStore;
+  let originalStoreValue;
+  baseStore.subscribe((v) => (originalStoreValue = v))();
   beforeAll(() => {
     updateImmediateSpy = jest.spyOn(REXVersionStore, "updateImmediate");
     updateSpy = jest.spyOn(REXVersionStore, "update");
   });
   afterAll(() => {
     jest.restoreAllMocks();
+    // Reset store bake to its original value
+    baseStore.set(originalStoreValue);
   });
   beforeEach(() => {
     jest.resetAllMocks();
   });
   it("Calls updateImmediate while value is undefined", async () => {
-    // @ts-expect-error baseStore is protected but the test is made reasonably
-    // more realistic by violating this visibility rule
-    const baseStore = REXVersionStore.baseStore;
     await getRexReleaseVersion();
     expect(updateImmediateSpy).toHaveBeenCalledTimes(1);
     await getRexReleaseVersion();

--- a/frontend/specs/abl.spec.ts
+++ b/frontend/specs/abl.spec.ts
@@ -5,35 +5,55 @@ import {
   jest,
   beforeEach,
   afterAll,
+  beforeAll,
 } from "@jest/globals";
 import type { Job } from "../src/ts/types";
 import {
   fetchABL,
+  fetchRexReleaseVersion,
   getLatestCodeVersionForBook,
   getLatestCodeVersionForJob,
+  getRexReleaseVersion,
   hasABLEntry,
   newABLentry,
 } from "../src/ts/abl";
+import * as stores from "../src/ts/stores";
 import { errorStore } from "../src/ts/stores";
 import {
+  Fetch,
   approvedBookWithDateFactory,
   bookFactory,
   jobFactory,
+  mockJSONResponse,
+  mockResponseStatus,
 } from "./spec-helpers";
 
+let errors: string[];
+const origFetch = window.fetch;
+const unsub = errorStore.subscribe((e) => (errors = e));
+let fetchSpy: jest.SpiedFunction<Fetch>;
+let consoleErrorSpy: jest.SpiedFunction<(...args: unknown[]) => void>;
+beforeAll(() => {
+  window.fetch = jest.fn<Fetch>();
+  fetchSpy = jest.spyOn(window, "fetch");
+  consoleErrorSpy = jest.spyOn(console, "error");
+});
+afterAll(() => {
+  window.fetch = origFetch;
+  jest.restoreAllMocks();
+  unsub();
+});
+beforeEach(() => {
+  // Reset history
+  jest.resetAllMocks();
+  // Silence error logging
+  consoleErrorSpy.mockImplementation(() => {});
+  errorStore.clear();
+});
+
 describe("newABLentry", () => {
-  let mockFetch;
-  let errors: string[];
-  const unsub = errorStore.subscribe((e) => (errors = e));
   beforeEach(() => {
-    mockFetch = jest
-      .fn<() => Promise<Response>>()
-      .mockResolvedValue({ status: 200 } as unknown as Response);
-    window.fetch = mockFetch as any;
-    errorStore.clear();
-  });
-  afterAll(() => {
-    unsub();
+    mockResponseStatus(fetchSpy, 200);
   });
   const testCases: { job: Job; code_version: string; expected: any }[] = [
     {
@@ -71,8 +91,8 @@ describe("newABLentry", () => {
     it(`calls fetch with the correct information -> ${args}`, async () => {
       const { job, code_version: codeVersion, expected } = args;
       await newABLentry(job, codeVersion);
-      const url: string = (mockFetch.mock.lastCall as any[])[0] as string;
-      const options = (mockFetch.mock.lastCall as any[])[1];
+      const url: string = (fetchSpy.mock.lastCall as any[])[0] as string;
+      const options = (fetchSpy.mock.lastCall as any[])[1];
       const body = JSON.parse(options.body);
       expect(errors[0]).toBeUndefined();
       expect(options.method).toBe("POST");
@@ -84,9 +104,7 @@ describe("newABLentry", () => {
   it("throws a specific error on auth error", async () => {
     const job = jobFactory.build();
     const codeVersion = "1";
-    window.fetch = jest
-      .fn<() => Promise<Response>>()
-      .mockResolvedValue({ status: 403 } as unknown as Response);
+    fetchSpy.mockResolvedValue({ status: 403 } as unknown as Response);
     await newABLentry(job, codeVersion);
     expect(errors.length).toBe(1);
     expect(errors[0]).toMatch(/do not.+permission.+entries/i);
@@ -170,25 +188,82 @@ describe("getLatestCodeVersionForJob", () => {
 });
 
 describe("fetchABL", () => {
-  let mockFetch;
-  let errors: string[];
-  const unsub = errorStore.subscribe((e) => (errors = e));
-  beforeEach(() => {
-    mockFetch = jest.fn<() => Promise<Response>>().mockResolvedValue({
-      status: 200,
-      json: async () => [],
-    } as unknown as Response);
-    window.fetch = mockFetch as any;
-    errorStore.clear();
-  });
-  afterAll(() => {
-    unsub();
-  });
-  it("fetches", async () => {
+  it("fetches the ABL without error", async () => {
+    mockJSONResponse(fetchSpy, []);
     const value = await fetchABL();
-    const url: string = (mockFetch.mock.lastCall as any[])[0] as string;
+    const url: string = (fetchSpy.mock.lastCall as any[])[0] as string;
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(errors[0]).toBeUndefined();
     expect(url).toBe("/api/abl/");
     expect(value).toStrictEqual([]);
+  });
+  it("sends errors to error store", async () => {
+    fetchSpy.mockRejectedValue("test");
+    const value = await fetchABL();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(value).toStrictEqual([]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toMatch(/test/);
+  });
+});
+
+describe("fetchRexReleaseVersion", () => {
+  it("fetches the REX release version without error", async () => {
+    mockJSONResponse(fetchSpy, { version: "test-version" });
+    const version = await fetchRexReleaseVersion();
+    const url: string = (fetchSpy.mock.lastCall as any[])[0] as string;
+    expect(errors[0]).toBeUndefined();
+    expect(url).toMatch(/rex-release-version/);
+    expect(version).toBe("test-version");
+  });
+  it("returns undefined and sends errors to error store on error", async () => {
+    fetchSpy.mockRejectedValue("test");
+    const value = await fetchRexReleaseVersion();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(value).toBeUndefined();
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toMatch(/test/);
+  });
+  it("only accepts strings", async () => {
+    mockJSONResponse(fetchSpy, { version: {} });
+    const value = await fetchRexReleaseVersion();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(value).toBeUndefined();
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toMatch(/Could not get REX release version/);
+  });
+});
+
+describe("getRexReleaseVersion", () => {
+  const { REXVersionStore } = stores;
+  let updateImmediateSpy: jest.SpiedFunction<() => Promise<void>>;
+  let updateSpy: jest.SpiedFunction<() => Promise<void>>;
+  beforeAll(() => {
+    updateImmediateSpy = jest.spyOn(REXVersionStore, "updateImmediate");
+    updateSpy = jest.spyOn(REXVersionStore, "update");
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  it("Calls updateImmediate while value is undefined", async () => {
+    // @ts-expect-error baseStore is protected but the test is made reasonably
+    // more realistic by violating this visibility rule
+    const baseStore = REXVersionStore.baseStore;
+    await getRexReleaseVersion();
+    expect(updateImmediateSpy).toHaveBeenCalledTimes(1);
+    await getRexReleaseVersion();
+    expect(updateImmediateSpy).toHaveBeenCalledTimes(2);
+    updateImmediateSpy.mockImplementation(async () => {
+      baseStore.set("test-version");
+    });
+    expect(await getRexReleaseVersion()).toBe("test-version");
+    expect(updateSpy).toHaveBeenCalledTimes(0);
+    expect(updateImmediateSpy).toHaveBeenCalledTimes(3);
+    expect(await getRexReleaseVersion()).toBe("test-version");
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateImmediateSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/specs/spec-helpers.ts
+++ b/frontend/specs/spec-helpers.ts
@@ -1,5 +1,24 @@
 import * as Factory from "factory.ts";
 import type { ApprovedBookWithDate, Book, Job, User } from "../src/ts/types";
+import type { jest } from "@jest/globals";
+
+export type Fetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit | undefined,
+) => Promise<Response>;
+
+export type FetchMock = jest.SpiedFunction<Fetch> | jest.Mock<Fetch>;
+
+export const mockResponseStatus = (mock: FetchMock, status: number) => {
+  mock.mockResolvedValue({ status } as unknown as Response);
+};
+
+export const mockJSONResponse = <T>(mock: FetchMock, json: T, status = 200) => {
+  mock.mockResolvedValue({
+    status,
+    json: async () => json,
+  } as unknown as Response);
+};
 
 // sfc32 credit: https://pracrand.sourceforge.net/
 function sfc32(a: number, b: number, c: number, d: number) {

--- a/frontend/src/components/ApproveBook.svelte
+++ b/frontend/src/components/ApproveBook.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import SegmentedButton, { Label, Segment } from "@smui/segmented-button";
   import CircularProgress from "@smui/circular-progress";
-  import { ABLStore, REXVersionStore } from "../ts/stores";
+  import { ABLStore } from "../ts/stores";
   import type { Job } from "../ts/types";
   import {
     getLatestCodeVersionForJob,

--- a/frontend/src/components/ApproveBook.svelte
+++ b/frontend/src/components/ApproveBook.svelte
@@ -1,29 +1,46 @@
 <script lang="ts">
   import SegmentedButton, { Label, Segment } from "@smui/segmented-button";
   import CircularProgress from "@smui/circular-progress";
-  import { ABLStore } from "../ts/stores";
+  import { ABLStore, REXVersionStore } from "../ts/stores";
   import type { Job } from "../ts/types";
-  import { getLatestCodeVersionForJob, newABLentry } from "../ts/abl";
+  import {
+    getLatestCodeVersionForJob,
+    getRexReleaseVersion,
+    newABLentry,
+  } from "../ts/abl";
   import Button from "@smui/button";
+  import { Icon } from "@smui/common";
   import { repoToString } from "../ts/utils";
 
   export let selectedJob: Job;
-  export let open;
-  let selectedCodeVersion;
+  export let open: boolean;
+
+  let selectedCodeVersion: string | undefined;
   let loading = false;
+  let choices: string[] = [];
+  let isValidEntry: boolean = false;
 
-  let choices: Array<string | undefined>;
+  const updateChoices = async () => {
+    let existingVersion = getLatestCodeVersionForJob($ABLStore, selectedJob);
+    if (existingVersion === undefined) {
+      existingVersion = await getRexReleaseVersion();
+    }
+    if (existingVersion === undefined) {
+      choices = [];
+    } else {
+      choices = [existingVersion, selectedJob.worker_version];
+    }
+    // Default to first entry (or undefined)
+    selectedCodeVersion = choices[0];
+  };
 
-  $: choices = Array.from(
-    new Set(
-      [
-        getLatestCodeVersionForJob($ABLStore, selectedJob),
-        selectedJob.worker_version,
-      ].filter((e) => e !== undefined),
-    ),
-  );
-  // Default to first entry
-  $: selectedCodeVersion = selectedCodeVersion ?? choices[0];
+  $: if (open === true) {
+    loading = true;
+    updateChoices().finally(() => {
+      loading = false;
+    });
+  }
+  $: isValidEntry = selectedCodeVersion !== undefined;
 </script>
 
 <div id="approve-book-frame">
@@ -35,37 +52,41 @@
     <label id="selected-code-version-label" for="selected-code-version"
       >Selected Minimum Code Version:</label
     >
-    <SegmentedButton
-      id="selected-code-version"
-      segments={choices}
-      let:segment
-      singleSelect
-      bind:selected={selectedCodeVersion}
-    >
-      <Segment {segment}>
-        <Label>{segment}</Label>
-      </Segment>
-    </SegmentedButton>
+    {#if choices.length > 0}
+      <SegmentedButton
+        id="selected-code-version"
+        segments={choices}
+        let:segment
+        singleSelect
+        bind:selected={selectedCodeVersion}
+      >
+        <Segment {segment}>
+          <Label>{segment}</Label>
+        </Segment>
+      </SegmentedButton>
+    {:else}
+      <div style="color: red; display: flex; align-items: center;">
+        <Icon class="material-icons">error</Icon>
+        <div>Could not get options for code version</div>
+      </div>
+    {/if}
     <div id="approve-action-container">
       <Button
         id="approve-button"
         color="secondary"
         variant="raised"
-        disabled={selectedCodeVersion === undefined}
+        disabled={!isValidEntry}
         on:click={() => {
-          if (selectedCodeVersion === undefined) {
-            throw new Error("No code version selected");
-          }
           const message = [
-            'Are you sure you wish to add the following to the ABL?',
-            '',
-            'Code Version:',
+            "Are you sure you wish to add the following to the ABL?",
+            "",
+            "Code Version:",
             `    ${selectedCodeVersion}`,
-            'Repository:',
+            "Repository:",
             `    ${repoToString(selectedJob.repository)}`,
-            'Commit sha:',
+            "Commit sha:",
             `    ${selectedJob.version}`,
-            'Books:',
+            "Books:",
             `    ${selectedJob.books.map((b) => b.slug).join(", ")}`,
           ];
           if (!confirm(message.join("\n"))) {

--- a/frontend/src/components/ApproveBook.svelte
+++ b/frontend/src/components/ApproveBook.svelte
@@ -3,11 +3,7 @@
   import CircularProgress from "@smui/circular-progress";
   import { ABLStore } from "../ts/stores";
   import type { Job } from "../ts/types";
-  import {
-    getLatestCodeVersionForJob,
-    getRexReleaseVersion,
-    newABLentry,
-  } from "../ts/abl";
+  import { getExistingCodeVersion, newABLentry } from "../ts/abl";
   import Button from "@smui/button";
   import { Icon } from "@smui/common";
   import { repoToString } from "../ts/utils";
@@ -21,14 +17,18 @@
   let isValidEntry: boolean = false;
 
   const updateChoices = async () => {
-    let existingVersion = getLatestCodeVersionForJob($ABLStore, selectedJob);
-    if (existingVersion === undefined) {
-      existingVersion = await getRexReleaseVersion();
-    }
+    const existingVersion = await getExistingCodeVersion(
+      $ABLStore,
+      selectedJob,
+    );
     if (existingVersion === undefined) {
       choices = [];
     } else {
-      choices = [existingVersion, selectedJob.worker_version];
+      const { worker_version: workerVersion } = selectedJob;
+      choices =
+        workerVersion === existingVersion
+          ? [workerVersion]
+          : [existingVersion, workerVersion];
     }
     // Default to first entry (or undefined)
     selectedCodeVersion = choices[0];

--- a/frontend/src/components/ApprovedBooksDialog.svelte
+++ b/frontend/src/components/ApprovedBooksDialog.svelte
@@ -5,7 +5,7 @@
   import type { ApprovedBookWithDate } from "../ts/types";
   import IconButton from "@smui/icon-button";
   import { getVersionLink, sortBy } from "../ts/utils";
-    import VersionLink from "./VersionLink.svelte";
+  import VersionLink from "./VersionLink.svelte";
 
   let sorted: ApprovedBookWithDate[] = [];
   let slice: ApprovedBookWithDate[] = [];

--- a/frontend/src/components/NewJobForm.svelte
+++ b/frontend/src/components/NewJobForm.svelte
@@ -5,11 +5,7 @@
   import Autocomplete from "@smui-extra/autocomplete";
   import Button from "@smui/button";
   import { Label } from "@smui/common";
-  import {
-    filterBooks,
-    handleError,
-    repoToString,
-  } from "../ts/utils";
+  import { filterBooks, handleError, repoToString } from "../ts/utils";
   import type { RepositorySummary } from "../ts/types";
   import { repoSummariesStore } from "../ts/stores";
 
@@ -21,7 +17,7 @@
     selectedRepo: string,
     selectedBook: string,
     selectedVersion: string,
-    selectedJobTypes: string[]
+    selectedJobTypes: string[],
   ) => Promise<void>;
 
   let previousRepo: string | null;
@@ -38,8 +34,8 @@
   function createSearchFunction(
     getOptions: (
       repoSummaries: RepositorySummary[],
-      lowerInput: string
-    ) => string[]
+      lowerInput: string,
+    ) => string[],
   ) {
     return async function (input: string) {
       let options: string[] = [];
@@ -82,7 +78,7 @@
       lowerInput = "";
     }
     const matches = filterBooks(repoSummaries, selectedRepo ?? "").filter(
-      (bookSlug) => bookSlug.toLocaleLowerCase().includes(lowerInput)
+      (bookSlug) => bookSlug.toLocaleLowerCase().includes(lowerInput),
     );
     matches.sort();
     return matches;
@@ -91,7 +87,7 @@
   async function setSelectedRepo(selectedBook) {
     if (selectedRepo) return;
     const repo = repoSummaries.find((r) =>
-      r.books.find((b) => b === selectedBook)
+      r.books.find((b) => b === selectedBook),
     );
     // https://svelte.dev/tutorial/tick
     await tick();
@@ -184,7 +180,7 @@
       selectedRepo ?? "",
       selectedBook ?? "",
       selectedVersion,
-      selectedJobTypes
+      selectedJobTypes,
     );
   }}
 >

--- a/frontend/src/ts/abl.ts
+++ b/frontend/src/ts/abl.ts
@@ -1,9 +1,15 @@
 import { RequireAuth } from "./fetch-utils";
+import { REXVersionStore } from "./stores";
 import type { Job, Book, ApprovedBookWithDate } from "./types";
 import { handleError } from "./utils";
 import { parseDateTime } from "./utils";
+import * as store from "svelte/store";
 
-export async function newABLentry(job: Job, codeVersion: string) {
+export async function newABLentry(job: Job, codeVersion: string | undefined) {
+  codeVersion = codeVersion?.trim();
+  if (codeVersion === undefined || codeVersion.length === 0) {
+    throw new Error("Invalid code version");
+  }
   const entries = job.books.map((b) => ({
     uuid: b.uuid,
     code_version: codeVersion,
@@ -60,7 +66,7 @@ export function getLatestCodeVersionForJob(
 }
 
 export async function fetchABL(): Promise<ApprovedBookWithDate[]> {
-  let abl: any;
+  let abl: ApprovedBookWithDate[];
   try {
     abl = await RequireAuth.fetchJson("/api/abl/");
   } catch (error) {
@@ -68,4 +74,27 @@ export async function fetchABL(): Promise<ApprovedBookWithDate[]> {
     abl = [];
   }
   return abl;
+}
+
+export async function fetchRexReleaseVersion(): Promise<string | undefined> {
+  try {
+    const resp = await fetch("/api/abl/rex-release-version");
+    const { version } = await resp.json();
+    if (typeof version !== "string") {
+      throw new Error("Could not get REX release version");
+    }
+    return version;
+  } catch (error) {
+    handleError(error);
+  }
+  return undefined;
+}
+
+export async function getRexReleaseVersion(): Promise<string | undefined> {
+  // If the value is undefined, immediately try to get a new value instead of
+  // allowing the update to be deferred
+  await (store.get(REXVersionStore) === undefined
+    ? REXVersionStore.updateImmediate()
+    : REXVersionStore.update());
+  return store.get(REXVersionStore);
 }

--- a/frontend/src/ts/abl.ts
+++ b/frontend/src/ts/abl.ts
@@ -98,3 +98,14 @@ export async function getRexReleaseVersion(): Promise<string | undefined> {
     : REXVersionStore.update());
   return store.get(REXVersionStore);
 }
+
+export async function getExistingCodeVersion(
+  approvedBooks: ApprovedBookWithDate[],
+  job: Job,
+) {
+  let existingVersion = getLatestCodeVersionForJob(approvedBooks, job);
+  if (existingVersion === undefined) {
+    existingVersion = await getRexReleaseVersion();
+  }
+  return existingVersion;
+}

--- a/frontend/src/ts/stores.ts
+++ b/frontend/src/ts/stores.ts
@@ -1,6 +1,6 @@
 import { derived, Readable, writable } from "svelte/store";
 import { getJobs } from "./jobs";
-import { MINUTES, SECONDS } from "./time";
+import { HOURS, SECONDS } from "./time";
 import type { ApprovedBookWithDate, Job, RepositorySummary } from "./types";
 import { fetchRepoSummaries, isJobComplete, parseDateTime } from "./utils";
 import { fetchABL, fetchRexReleaseVersion } from "./abl";
@@ -193,5 +193,5 @@ export const ABLStore = new (Pollable(
 
 export const REXVersionStore = new (RateLimited(
   APIStore<string | undefined>,
-  (5 * MINUTES) / SECONDS,
+  (1 * HOURS) / SECONDS,
 ))(asyncWritable(undefined), fetchRexReleaseVersion);


### PR DESCRIPTION
fixes openstax/ce#2227

To get options for minimum code version:
1. Try to get the last version used (if more than one book is being approved, all code versions must match for this to work)
2. Try to get the current REX release
3. If neither approach works, the code version selection will show an error and the approve button will be disabled