### PR TITLE
2232 only newest slugs autocomplete

### DIFF
--- a/backend/app/app/data_models/models.py
+++ b/backend/app/app/data_models/models.py
@@ -138,11 +138,11 @@ class RepositoryGetter(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
         repository = self._obj
         if key == "books":
-            books = set()
-            for commit in repository.commits:
-                for book in commit.books:
-                    books.add(book.slug)
-            return list(books)
+            commits = repository.commits
+            if len(commits) == 0:
+                return []
+            newest_commit = max(commits, key=lambda c: c.timestamp)
+            return [book.slug for book in newest_commit.books]
         else:
             try:
                 return getattr(self._obj, key)

--- a/backend/app/app/data_models/models.py
+++ b/backend/app/app/data_models/models.py
@@ -138,11 +138,11 @@ class RepositoryGetter(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
         repository = self._obj
         if key == "books":
-            commits = repository.commits
-            if len(commits) == 0:
+            commits = (c for c in repository.commits if len(c.books) > 0)
+            newest = max(commits, key=lambda c: c.timestamp, default=None)
+            if newest is None:
                 return []
-            newest_commit = max(commits, key=lambda c: c.timestamp)
-            return [book.slug for book in newest_commit.books]
+            return [book.slug for book in newest.books]
         else:
             try:
                 return getattr(self._obj, key)

--- a/backend/app/tests/unit/api/endpoints/test_github.py
+++ b/backend/app/tests/unit/api/endpoints/test_github.py
@@ -24,3 +24,4 @@ def test_repositories(
     # the correct information
     first = payload[0]
     assert first == RepositorySummary.from_orm(fake_data.FAKE_REPO)
+    assert first["books"] == [b.slug for b in fake_data.FAKE_COMMIT2.books]

--- a/backend/app/tests/unit/conftest.py
+++ b/backend/app/tests/unit/conftest.py
@@ -71,10 +71,26 @@ def fake_data():
     class FakeData:
         AUDIT_DATA = {"created_at": now, "updated_at": now}
         FAKE_REPO = Repository(name="osbooks-fake-book", owner="openstax", id=1)
-        FAKE_COMMIT = Commit(id=1, repository_id=FAKE_REPO.id)
+        FAKE_COMMIT = Commit(
+            id=1,
+            repository_id=FAKE_REPO.id,
+            timestamp=datetime.fromisoformat("2024-06-05T17:30:24.311Z"),
+        )
+        FAKE_COMMIT2 = Commit(
+            id=2,
+            repository_id=FAKE_REPO.id,
+            timestamp=datetime.fromisoformat("2024-06-05T17:30:53.909Z"),
+        )
         FAKE_BOOK = Book(
             commit_id=FAKE_COMMIT.id,
             slug="test",
+            uuid="ooooooo",
+            edition=0,
+            style="test",
+        )
+        FAKE_BOOK2 = Book(
+            commit_id=FAKE_COMMIT2.id,
+            slug="test-2",
             uuid="ooooooo",
             edition=0,
             style="test",
@@ -103,7 +119,8 @@ def fake_data():
         FAKE_BOOK_JOB = BookJob(book_id=FAKE_BOOK.id, job_id=FAKE_JOB.id)
         FAKE_BOOK_JOB.book = FAKE_BOOK
         FAKE_COMMIT.books = [FAKE_BOOK]
-        FAKE_REPO.commits = [FAKE_COMMIT]
+        FAKE_COMMIT2.books = [FAKE_BOOK2]
+        FAKE_REPO.commits = [FAKE_COMMIT, FAKE_COMMIT2]
         FAKE_JOB.books = [FAKE_BOOK_JOB]
         FAKE_JOB.status = FAKE_STATUS
         FAKE_JOB.user = FAKE_USER

--- a/backend/app/tests/unit/test_models.py
+++ b/backend/app/tests/unit/test_models.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+from app.data_models.models import RepositoryGetter
+from app.db.schema import Book, Commit, Repository
+
+
+def test_repository_getter_zero_commits():
+    # GIVEN: A repository containing zero commits
+    repo = Repository(id=1, name="test")
+    repo.commits = []
+    # WHEN: The repository getter tries to get books
+    # THEN: It returns an empty list instead of the default (None)
+    getter = RepositoryGetter(repo)
+    books = getter.get("books", None)
+    assert books == []
+
+
+def test_repository_getter_zero_books():
+    # GIVEN: A repository containing one commit containing zero books
+    repo = Repository(id=1, name="test")
+    commit = Commit(
+        id=1, timestamp=datetime.fromisoformat("2024-06-05T18:54:16.031Z")
+    )
+    repo.commits = [commit]
+    commit.books = []
+    # WHEN: The repository getter tries to get books
+    # THEN: It returns an empty list instead of the default (None)
+    getter = RepositoryGetter(repo)
+    books = getter.get("books", None)
+    assert books == []
+
+
+def test_repository_getter_one_book():
+    # GIVEN: A repository containing one commit containing one book
+    repo = Repository(id=1, name="test")
+    commit = Commit(
+        id=1, timestamp=datetime.fromisoformat("2024-06-05T18:54:16.031Z")
+    )
+    book = Book(slug="test-slug")
+    repo.commits = [commit]
+    commit.books = [book]
+    # WHEN: The repository getter tries to get books
+    # THEN: It returns a list of book slugs
+    getter = RepositoryGetter(repo)
+    books = getter.get("books", None)
+    assert books == [book.slug]
+
+
+def test_repository_getter_multiple_matches():
+    # GIVEN: A repository containing two commits containing one or more books each
+    repo = Repository(id=1, name="test")
+    commit = Commit(
+        id=1, timestamp=datetime.fromisoformat("2024-06-05T18:58:16.011Z")
+    )
+    commit2 = Commit(
+        id=2, timestamp=datetime.fromisoformat("2024-06-05T19:03:21.271Z")
+    )
+    book = Book(slug="test-slug")
+    book2 = Book(slug="test-slug-2")
+    book3 = Book(slug="test-slug-3")
+    commit2.books = [book2, book3]
+    commit.books = [book]
+    repo.commits = [commit, commit2]
+    # WHEN: The repository getter tries to get books
+    # THEN: It returns a list of book slugs from the newest commit
+    getter = RepositoryGetter(repo)
+    books = getter.get("books", None)
+    assert books == [b.slug for b in commit2.books]


### PR DESCRIPTION
fixes openstax/ce#2232

- Only list slugs from the newest commit in the book autocomplete list

A more long-term solution might be to switch around the version and book input boxes, so that it is intuitive to enter version before book, have version default to main, and have the frontend query for the slugs based on repository and version.

## Current version

Lists all books known to have existed in any version of the repository

<img width="1193" alt="Screenshot 2024-06-05 at 1 39 02 PM" src="https://github.com/openstax/corgi/assets/33585550/5d77cc8d-a180-4b50-8bba-8ecae472dd43">

## New version:

Lists books that exist in the newest commit on the repository (regardless of branch)

<img width="1188" alt="Screenshot 2024-06-05 at 1 38 40 PM" src="https://github.com/openstax/corgi/assets/33585550/46f5cca2-b537-497a-a9ce-7bd8758a4855">
