### PR TITLE
Get rex release version from github repository

### DIFF
--- a/backend/app/app/api/endpoints/abl.py
+++ b/backend/app/app/api/endpoints/abl.py
@@ -5,13 +5,15 @@ from httpx import AsyncClient
 from sqlalchemy.orm import Session
 
 import app.service.abl as abl_service
-from app.core.auth import RequiresRole
+from app.core.auth import RequiresRole, active_user
 from app.data_models.models import (
     ApprovedBook,
     RequestApproveBook,
     Role,
+    UserSession,
 )
 from app.db.utils import get_db
+from app.github.client import github_client
 
 router = APIRouter()
 
@@ -45,7 +47,7 @@ async def add_to_abl(
 
 
 @router.get("/rex-release-version")
-async def get_rex_release_version():
-    async with AsyncClient() as client:
+async def get_rex_release_version(user: UserSession = Depends(active_user)):
+    async with github_client(user) as client:
         version = await abl_service.get_rex_release_version(client)
         return {"version": version}

--- a/backend/app/app/core/config.py
+++ b/backend/app/app/core/config.py
@@ -36,6 +36,11 @@ GITHUB_REPO_PREFIX = os.getenv("GITHUB_REPO_PREFIX", "osbooks")
 REX_WEB_RELEASE_URL = os.getenv(
     "REX_WEB_RELEASE_URL", "https://openstax.org/rex/release.json"
 )
+REX_WEB_ARCHIVE_CONFIG = os.getenv(
+    "REX_WEB_ARCHIVE_CONFIG",
+    # owner:repo:path
+    "openstax:rex-web:src/config.archive-url.json",
+)
 
 # GITHUB OAUTH
 CLIENT_ID = os.getenv("GITHUB_OAUTH_ID")

--- a/backend/app/app/github/__init__.py
+++ b/backend/app/app/github/__init__.py
@@ -2,6 +2,7 @@ from app.github.api import (
     AccessDeniedError,
     get_book_repository,
     get_collections,
+    get_file_content,
     get_user,
     get_user_repositories,
     get_user_role,

--- a/backend/app/app/service/abl.py
+++ b/backend/app/app/service/abl.py
@@ -1,4 +1,4 @@
-import re
+import json
 from typing import Any, Dict, List, Optional
 
 from httpx import AsyncClient, HTTPStatusError
@@ -16,6 +16,7 @@ from app.db.schema import (
     Consumer,
     Repository,
 )
+from app.github.api import get_file_content
 
 
 async def get_rex_release_json(client: AsyncClient):
@@ -38,15 +39,18 @@ async def get_rex_books(client: AsyncClient):
 
 
 async def get_rex_release_version(client: AsyncClient):
-    rex_release = await get_rex_release_json(client)
-    archive_url = rex_release.get("archiveUrl", "").strip()
-    if archive_url == "":
-        raise CustomBaseError("Could not find valid REX archive URL")
-    # Search for: %Y%m%d.%H%M%S
-    version_matches = re.findall(r"\d{8}\.\d{6}", archive_url)
-    if len(version_matches) != 1:
-        raise CustomBaseError("Could not determine REX release version")
-    return version_matches[0]
+    owner, repo, path = config.REX_WEB_ARCHIVE_CONFIG.split(":", 2)
+    try:
+        raw_contents = await get_file_content(client, owner, repo, path)
+    except HTTPStatusError as he:
+        raise CustomBaseError(
+            f"Failed to fetch rex release version: {he.response.status_code}"
+        ) from he
+    contents = json.loads(raw_contents)
+    version = contents.get("REACT_APP_ARCHIVE", "").strip()
+    if not version:
+        raise CustomBaseError("Could not find valid REX version")
+    return version
 
 
 def get_rex_book_versions(rex_books: Dict[str, Any], book_uuids: List[str]):

--- a/backend/app/app/service/abl.py
+++ b/backend/app/app/service/abl.py
@@ -17,6 +17,7 @@ from app.db.schema import (
     Repository,
 )
 from app.github.api import get_file_content
+from app.github.client import AuthenticatedClient
 
 
 async def get_rex_release_json(client: AsyncClient):
@@ -38,7 +39,7 @@ async def get_rex_books(client: AsyncClient):
     return release_json["books"]
 
 
-async def get_rex_release_version(client: AsyncClient):
+async def get_rex_release_version(client: AuthenticatedClient):
     owner, repo, path = config.REX_WEB_ARCHIVE_CONFIG.split(":", 2)
     try:
         raw_contents = await get_file_content(client, owner, repo, path)

--- a/backend/app/tests/unit/conftest.py
+++ b/backend/app/tests/unit/conftest.py
@@ -18,6 +18,7 @@ def pytest_configure(config):
     )
     init_test_data = config.getoption("--init-test-data")
     if init_test_data:
+        os.environ.setdefault("VCR_RECORD", "1")
         token = config.getoption("--github-token")
         if token is not None:
             from tests.unit.init_test_data import main

--- a/backend/app/tests/unit/data/get_file_content.yaml
+++ b/backend/app/tests/unit/data/get_file_content.yaml
@@ -1,0 +1,18 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      host:
+      - api.github.com
+    method: GET
+    uri: https://api.github.com/repos/openstax/rex-web/contents/src/config.archive-url.json
+  response:
+    content: '{"name":"config.archive-url.json","path":"src/config.archive-url.json","sha":"ddd2befbcff5578dda01dda94cd6c2474999d876","size":95,"url":"https://api.github.com/repos/openstax/rex-web/contents/src/config.archive-url.json?ref=main","html_url":"https://github.com/openstax/rex-web/blob/main/src/config.archive-url.json","git_url":"https://api.github.com/repos/openstax/rex-web/git/blobs/ddd2befbcff5578dda01dda94cd6c2474999d876","download_url":"https://raw.githubusercontent.com/openstax/rex-web/main/src/config.archive-url.json","type":"file","content":"ewogICJSRUFDVF9BUFBfQVJDSElWRSI6ICIyMDI0MDkxMC4xNjEyMjciLAog\nICJSRUFDVF9BUFBfQVJDSElWRV9VUkxfQkFTRSI6ICIvYXBwcy9hcmNoaXZl\nLyIKfQo=\n","encoding":"base64","_links":{"self":"https://api.github.com/repos/openstax/rex-web/contents/src/config.archive-url.json?ref=main","git":"https://api.github.com/repos/openstax/rex-web/git/blobs/ddd2befbcff5578dda01dda94cd6c2474999d876","html":"https://github.com/openstax/rex-web/blob/main/src/config.archive-url.json"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - github.com
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/backend/app/tests/unit/init_test_data.py
+++ b/backend/app/tests/unit/init_test_data.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -6,15 +7,24 @@ from typing import cast
 
 import vcr
 from httpx import AsyncClient
+from vcr.record_mode import RecordMode
 
+import app.core.config as config
 from app.github import (
     AuthenticatedClient,
     get_book_repository,
     get_collections,
+    get_file_content,
     get_user,
     get_user_repositories,
     get_user_teams,
 )
+
+vcr_args = {
+    "record_mode": RecordMode.NEW_EPISODES
+    if os.getenv("VCR_RECORD") == "1"
+    else RecordMode.NONE
+}
 
 
 def apply_key_whitelist(d, whitelist):
@@ -31,13 +41,14 @@ class BaseSanitizer:
         self.vcr = vcr
 
     def transform(self, d):
-        request_headers = d["interactions"][0]["request"]["headers"]
-        response_headers = d["interactions"][0]["response"]["headers"]
-        for headers, whitelist in (
-            (request_headers, ("host",)),
-            (response_headers, ("content-type", "server")),
-        ):
-            apply_key_whitelist(headers, whitelist)
+        for interaction in d["interactions"]:
+            request_headers = interaction["request"]["headers"]
+            response_headers = interaction["response"]["headers"]
+            for headers, whitelist in (
+                (request_headers, ("host",)),
+                (response_headers, ("content-type", "server")),
+            ):
+                apply_key_whitelist(headers, whitelist)
 
     def serialize(self, d, *args, **kwargs):
         self.transform(d)
@@ -58,11 +69,12 @@ class UserSanitizer(BaseSanitizer):
         import json
 
         super().transform(d)
-        body = json.loads(d["interactions"][0]["response"]["content"])
-        # Keep exactly what is used by the backend, delete extra data
-        apply_key_whitelist(body, ("login", "avatar_url", "id"))
-        # HACK: Set the content to save from the response
-        d["interactions"][0]["response"]["content"] = json.dumps(body)
+        for interaction in d["interactions"]:
+            body = json.loads(interaction["response"]["content"])
+            # Keep exactly what is used by the backend, delete extra data
+            apply_key_whitelist(body, ("login", "avatar_url", "id"))
+            # HACK: Set the content to save from the response
+            interaction["response"]["content"] = json.dumps(body)
 
 
 DATA_DIR = str(Path(__file__).parent / "data")
@@ -73,12 +85,14 @@ my_vcr.register_serializer("base_sanitizer", BaseSanitizer(my_vcr))
 my_vcr.register_serializer("user_sanitizer", UserSanitizer(my_vcr))
 
 
-@my_vcr.use_cassette("get_user.yaml", serializer="user_sanitizer")
+@my_vcr.use_cassette("get_user.yaml", serializer="user_sanitizer", **vcr_args)
 async def mock_get_user(client, access_token):
     return await get_user(client, access_token)
 
 
-@my_vcr.use_cassette("get_user_teams.yaml", serializer="base_sanitizer")
+@my_vcr.use_cassette(
+    "get_user_teams.yaml", serializer="base_sanitizer", **vcr_args
+)
 async def mock_get_user_teams(client, user):
     import app.github.api
 
@@ -88,19 +102,32 @@ async def mock_get_user_teams(client, user):
     return teams
 
 
-@my_vcr.use_cassette("get_user_repositories.yaml", serializer="base_sanitizer")
+@my_vcr.use_cassette(
+    "get_user_repositories.yaml", serializer="base_sanitizer", **vcr_args
+)
 async def mock_get_user_repositories(client, query):
     return await get_user_repositories(client, query)
 
 
-@my_vcr.use_cassette("get_book_repository.yaml", serializer="base_sanitizer")
+@my_vcr.use_cassette(
+    "get_book_repository.yaml", serializer="base_sanitizer", **vcr_args
+)
 async def mock_get_book_repository(client, repo_name, repo_owner, version):
     return await get_book_repository(client, repo_name, repo_owner, version)
 
 
-@my_vcr.use_cassette("get_collections.yaml", serializer="base_sanitizer")
+@my_vcr.use_cassette(
+    "get_collections.yaml", serializer="base_sanitizer", **vcr_args
+)
 async def mock_get_collections(client, repo_name, repo_owner, commit_sha):
     return await get_collections(client, repo_name, repo_owner, commit_sha)
+
+
+@my_vcr.use_cassette(
+    "get_file_content.yaml", serializer="base_sanitizer", **vcr_args
+)
+async def mock_get_file_content(client, owner, repo, path, ref=None):
+    return await get_file_content(client, owner, repo, path, ref)
 
 
 async def async_main(access_token: str):
@@ -114,6 +141,9 @@ async def async_main(access_token: str):
         )
         await mock_get_book_repository(client, "tiny-book", "openstax", "main")
         await mock_get_collections(client, "tiny-book", "openstax", "main")
+        await mock_get_file_content(
+            client, *config.REX_WEB_ARCHIVE_CONFIG.split(":", 2)
+        )
 
 
 def main(access_token):


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-550

Get the version from the github repo directly.

Edit: Sorry about the cruft around init_test_data. It's a bit of tech debt that became relevant with the addition of `get_file_content`. This test data is used for some unit tests and for github api mocking for local development (so that you do not need an api token).